### PR TITLE
fix: Omit date from recommendation if it's empty

### DIFF
--- a/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
+++ b/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
@@ -61,7 +61,8 @@ public class TherapieplanToRecommendationMapper extends TherapieplanMapper<List<
                             .withPriority(priority(p))
                             //.withSupportingVariants() // TODO: Einfügen, wenn OS.Molekulargenetik fertig
                             ;
-                    var issuedOn = issuedOn(p);
+
+                    var issuedOn = mapperUtils.einzelempfehlungMtbDate(p);
                     if (issuedOn != null && !issuedOn.isEmpty()) {
                             builder.withIssuedOn(issuedOn);
                     }
@@ -84,10 +85,6 @@ public class TherapieplanToRecommendationMapper extends TherapieplanMapper<List<
                     return recommendation;
                 })
                 .collect(Collectors.toList());
-    }
-
-    private String issuedOn(Procedure procedure) {
-        return mapperUtils.einzelempfehlungMtbDate(procedure);
     }
 
     private Recommendation.Priority priority(Procedure procedure) {

--- a/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
+++ b/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
@@ -57,11 +57,14 @@ public class TherapieplanToRecommendationMapper extends TherapieplanMapper<List<
                     var builder = Recommendation.builder()
                             .withId(anonymizeId(p))
                             .withPatient(getPatientId(procedure))
-                            .withIssuedOn(issuedOn(p))
                             .withLevelOfEvidence(levelOfEvidence(p))
                             .withPriority(priority(p))
                             //.withSupportingVariants() // TODO: Einfügen, wenn OS.Molekulargenetik fertig
                             ;
+                    var issuedOn = issuedOn(p);
+                    if (issuedOn != null && !issuedOn.isEmpty()) {
+                            builder.withIssuedOn(issuedOn);
+                    }
 
                     // Aktuell nur eine einzige Referenz, später ggf mehrere in Datenmodell V2
                     mapperUtils.getMolekulargenetikProcedureIdsForEinzelempfehlung(p)


### PR DESCRIPTION
`mapperUtils.einzelempfehlungMtbDate` produziert Warnungen, bevor es einen leeren String zurückgibt, aber `"issuedOn": "",` im erzeugten JSON bringt bwHC dazu, den Import mit einem Fehler abzubrechen.

Mit dieser Änderung ist es nur eine Warnung und der Rest der Daten wird verarbeitet.