### PR TITLE
fix: Get the reference to OS.Molekulargenetik from the correct procedure

### DIFF
--- a/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
+++ b/src/main/java/de/ukw/ccc/dnpmexport/mapper/TherapieplanToRecommendationMapper.java
@@ -53,7 +53,7 @@ public class TherapieplanToRecommendationMapper extends TherapieplanMapper<List<
                 .stream()
                 .filter(p -> p.getParentProcedureId() == procedure.getId())
                 .map(p -> {
-                    var molgenref = procedure.getValue("refosmolekulargenetik");
+                    var molgenref = p.getValue("refosmolekulargenetik");
                     var builder = Recommendation.builder()
                             .withId(anonymizeId(p))
                             .withPatient(getPatientId(procedure))


### PR DESCRIPTION
I was going through some warnings in the ETL-Processor and saw "Referenz auf NGS-Befund" missing. I looked into the relevant part of the code and I think there was a mix-up of `procedure` and `p`: The field `refosmolekulargenetik` is in DNPM UF Einzelempfehlung and not in DNPM Therapieplan.

With this change, the warning is gone.