### PR TITLE
fix: Correctly differentiate Molekulargenetik Ergebnis

### DIFF
--- a/src/main/java/de/ukw/ccc/dnpmexport/mapper/MolekulargenetikToNgsReportMapper.java
+++ b/src/main/java/de/ukw/ccc/dnpmexport/mapper/MolekulargenetikToNgsReportMapper.java
@@ -81,7 +81,7 @@ public class MolekulargenetikToNgsReportMapper extends MolekulargenetikMapper<Op
                 .stream()
                 .filter(p -> p.getParentProcedureId() == procedure.getId())
                 // Einfache Variante
-                .filter(p -> p.getValue("Ergebnis").toString().equals("P"))
+                .filter(p -> p.getValue("Ergebnis").getString().equals("P"))
                 .map(
                         p -> {
                             var builder = SimpleVariant.builder().withId(anonymizeId(p));


### PR DESCRIPTION
The export didn't contain `ngsReports[0].simpleVariants`, so I figured out some of the filters in `getSimpleVariants` didn't work they way they were intended to.

It was the second one: `toString()` gives `de.itc.onkostar.api.Item@...`, `getString()` actually gives `P`.